### PR TITLE
Add version shim over `ECDSA_SIG_get0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM swift:5.0
 
 WORKDIR /code
-RUN apt-get install openssl libssl-dev
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    openssl libssl-dev
 COPY Package.swift /code/.
 RUN swift package resolve
 COPY ./Sources /code/Sources

--- a/Sources/APNSwift/APNSwiftSigner.swift
+++ b/Sources/APNSwift/APNSwiftSigner.swift
@@ -53,15 +53,12 @@ public struct APNSwiftSigner {
         }
         defer { ECDSA_SIG_free(.init(sig)) }
 
-        let pr = UnsafeMutablePointer<UnsafePointer<BIGNUM>?>.allocate(capacity: 1)
-        let ps = UnsafeMutablePointer<UnsafePointer<BIGNUM>?>.allocate(capacity: 1)
+        var r : UnsafePointer<BIGNUM>? = nil
+        var s : UnsafePointer<BIGNUM>? = nil
         
         // as this method is `get0` there is no requirement to free those pointers: ECDSA_SIG will free them for us.
-        CAPNSOpenSSL_ECDSA_SIG_get0(.init(sig), pr, ps)
+        CAPNSOpenSSL_ECDSA_SIG_get0(.init(sig), &r, &s)
         
-        let r = pr.pointee
-        let s = ps.pointee
-
         var rb = [UInt8](repeating: 0, count: Int(BN_num_bits(r)+7)/8)
         var sb = [UInt8](repeating: 0, count: Int(BN_num_bits(s)+7)/8)
         let lenr = Int(BN_bn2bin(r, &rb))

--- a/Sources/APNSwift/APNSwiftSigner.swift
+++ b/Sources/APNSwift/APNSwiftSigner.swift
@@ -59,16 +59,14 @@ public struct APNSwiftSigner {
         // as this method is `get0` there is no requirement to free those pointers: ECDSA_SIG will free them for us.
         CAPNSOpenSSL_ECDSA_SIG_get0(.init(sig), &r, &s)
         
-        var byteBuffer = ByteBufferAllocator().buffer(capacity: Int(BN_num_bits(r)+7)/8 + Int(BN_num_bits(s)+7)/8)
-        
-        byteBuffer.writeWithUnsafeMutableBytes { (p) -> Int in
-            return Int(BN_bn2bin(r, p.baseAddress?.assumingMemoryBound(to: UInt8.self)))
-        }
-        
-        byteBuffer.writeWithUnsafeMutableBytes { (p) -> Int in
-            return Int(BN_bn2bin(s, p.baseAddress?.assumingMemoryBound(to: UInt8.self)))
-        }
-        
-        return byteBuffer
+        var rb = [UInt8](repeating: 0, count: Int(BN_num_bits(r)+7)/8)
+        var sb = [UInt8](repeating: 0, count: Int(BN_num_bits(s)+7)/8)
+        let lenr = Int(BN_bn2bin(r, &rb))
+        let lens = Int(BN_bn2bin(s, &sb))
+
+        var signatureBytes = ByteBufferAllocator().buffer(capacity: lenr + lens)
+        signatureBytes.writeBytes(rb[0..<lenr])
+        signatureBytes.writeBytes(sb[0..<lens])
+        return signatureBytes
     }
 }

--- a/Sources/CAPNSOpenSSL/shim.h
+++ b/Sources/CAPNSOpenSSL/shim.h
@@ -9,6 +9,18 @@
 #include <openssl/crypto.h>
 
 
+/// ECDSA_SIG_get0() returns internal pointers the r and s values contained in
+/// sig and stores them in *pr and *ps, respectively. The pointer pr or ps can
+/// be NULL, in which case the corresponding value is not returned.
+static inline void CAPNSOpenSSL_ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps) {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+        if (pr != NULL)
+            *pr = sig->r;
+        if (ps != NULL)
+            *ps = sig->s;
+#else
+        ECDSA_SIG_get0(sig, pr, ps);
 #endif
+}
 
-
+#endif

--- a/Tests/APNSwiftJWTTests/JWTTests.swift
+++ b/Tests/APNSwiftJWTTests/JWTTests.swift
@@ -55,7 +55,7 @@ final class JWTTests: XCTestCase {
         }
     }
     
-    func testJWTSiging() throws {
+    func testJWTSigning() throws {
         let teamID = "8RX5AF8F6Z"
         let keyID = "9N8238KQ6Z"
         let date = Date()
@@ -79,7 +79,7 @@ cc94a66VttRZgVg6jE/ju+2mdHP7JWLmcQ==
     
     static var allTests = [
         ("testJWTEncodingAndSign", testJWTEncoding),
-        ("testJWTSiging", testJWTSiging),
+        ("testJWTSigning", testJWTSigning),
     ]
 }
 

--- a/Tests/APNSwiftJWTTests/JWTTests.swift
+++ b/Tests/APNSwiftJWTTests/JWTTests.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import XCTest
+import NIO
 @testable import APNSwift
 
 final class JWTTests: XCTestCase {
@@ -53,8 +54,32 @@ final class JWTTests: XCTestCase {
             XCTFail("Payload can't be decoded")
         }
     }
+    
+    func testJWTSiging() throws {
+        let teamID = "8RX5AF8F6Z"
+        let keyID = "9N8238KQ6Z"
+        let date = Date()
+        let jwt = APNSwiftJWT(keyID: keyID, teamID: teamID, issueDate: date, expireDuration: 10.0)
+        
+        let privateKey = """
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIEY5/amzr1QgHrLNZ8eHu926YERGWqB6QaDpNFcGxjsToAoGCCqGSM49
+AwEHoUQDQgAEdbP7WQ/U4e5/CAqoBxatQb/5CEgJ070yMNGmWg5O6v2Q4M0l4CXK
+cc94a66VttRZgVg6jE/ju+2mdHP7JWLmcQ==
+-----END EC PRIVATE KEY-----
+"""
+        
+        var buffer = ByteBufferAllocator().buffer(capacity: privateKey.count)
+        buffer.writeString(privateKey)
+        
+        let signer = try APNSwiftSigner(buffer: buffer)
+        let sig = try signer.sign(digest: try jwt.getDigest().fixedDigest)
+        XCTAssertEqual(sig.readableBytes, 64) // len(r) + len(s) == 64 byte
+    }
+    
     static var allTests = [
         ("testJWTEncodingAndSign", testJWTEncoding),
+        ("testJWTSiging", testJWTSiging),
     ]
 }
 


### PR DESCRIPTION
#36

Hey, this would be my suggestion for the version shim as @Lukasa suggested.

Not sure if it is cool to put this directly in `shim.h`.

Also not sure if my use of the `OpaquePointer` tricks is correct (CC @Lukasa).

I've added a test for the signing and ran it on Linux (`swift:5.0-xenial` and `swift:5.0`), seems to be fine 🤞 