### PR TITLE
Fix toManyProviderTokenUpdates error

### DIFF
--- a/Sources/APNSwift/APNSwiftBearerToken.swift
+++ b/Sources/APNSwift/APNSwiftBearerToken.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public struct APNSwiftBearerToken {
+public class APNSwiftBearerToken {
     let configuration: APNSwiftConfiguration
     let timeout: TimeInterval
     var createdAt: TimeInterval?
@@ -26,7 +26,7 @@ public struct APNSwiftBearerToken {
     }
     
     public var token: String? {
-        mutating get {
+        get {
             let now = Date().timeIntervalSince1970
             guard let existingToken = cachedToken, let timeCreated = createdAt, (now - timeCreated) <= timeout else {
                 cachedToken = try? createToken()

--- a/Sources/APNSwift/APNSwiftRequestEncoder.swift
+++ b/Sources/APNSwift/APNSwiftRequestEncoder.swift
@@ -27,7 +27,7 @@ internal final class APNSwiftRequestEncoder<Notification>: ChannelOutboundHandle
     typealias OutboundOut = HTTPClientRequestPart
 
     let configuration: APNSwiftConfiguration
-    var bearerToken: APNSwiftBearerToken
+    let bearerToken: APNSwiftBearerToken
     let deviceToken: String
     let priority: Int?
     let expiration: Date?


### PR DESCRIPTION
I believe that in the current implementation you can still have `toManyProviderTokenUpdates` error. It is because `APNSwiftBearerToken` is a structure and `APNSwiftRequestEncoder` always get own copy of  `APNSwiftBearerToken`, so when  `APNSwiftBearerToken` store its `cachedToken` it is available only in this exact copy. When you call `send<Notification>(...)` you create a new `APNSwiftRequestEncoder` with a new copy of `APNSwiftBearerToken`, that don't have  `cachedToken`. The easiest way to fix it is to change `APNSwiftBearerToken` to class, so it doesn't have copies and when you set `cachedToken` it stays. 