### PR TITLE
Initial swift log package.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.10.1")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.4.0")),
         .package(url: "https://github.com/apple/swift-nio-http2.git", .upToNextMajor(from: "1.6.0")),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .systemLibrary(
@@ -26,7 +27,8 @@ let package = Package(
         .target(name: "APNSwiftPemExample", dependencies: ["APNSwift"]),
         .testTarget(name: "APNSwiftJWTTests", dependencies: ["APNSwift"]),
         .testTarget(name: "APNSwiftTests", dependencies: ["APNSwift"]),
-        .target(name: "APNSwift", dependencies: ["NIO",
+        .target(name: "APNSwift", dependencies: ["Logging",
+                                                "NIO",
                                                 "NIOSSL",
                                                 "NIOHTTP1",
                                                 "NIOHTTP2",

--- a/Sources/APNSwift/APNSwiftBearerTokenFactory.swift
+++ b/Sources/APNSwift/APNSwiftBearerTokenFactory.swift
@@ -26,8 +26,10 @@ internal final class APNSwiftBearerTokenFactory {
         self.eventLoop = eventLoop
         self.eventLoop.assertInEventLoop()
         self.configuration = configuration
+        self.configuration.logger.info("Token - making new token")
         self.currentBearerToken = try APNSwiftBearerTokenFactory.makeNewBearerToken(configuration: configuration)
         self.updateTask = eventLoop.scheduleRepeatedTask(initialDelay: .minutes(55), delay: .minutes(55)) { task in
+            self.configuration.logger.info("Token - updating token")
             self.currentBearerToken = try APNSwiftBearerTokenFactory.makeNewBearerToken(configuration: configuration)
         }
     }
@@ -37,6 +39,7 @@ internal final class APNSwiftBearerTokenFactory {
         self.cancelled = true
         self.updateTask?.cancel()
         self.updateTask = nil
+        self.configuration.logger.info("Token - killed")
     }
 
     deinit {

--- a/Sources/APNSwift/APNSwiftBearerTokenFactory.swift
+++ b/Sources/APNSwift/APNSwiftBearerTokenFactory.swift
@@ -26,10 +26,10 @@ internal final class APNSwiftBearerTokenFactory {
         self.eventLoop = eventLoop
         self.eventLoop.assertInEventLoop()
         self.configuration = configuration
-        self.configuration.logger?.debug("Creating a new APNS token", metadata: ["origin": "APNSwift"])
+        self.configuration.logger?.debug("Creating a new APNS token")
         self.currentBearerToken = try APNSwiftBearerTokenFactory.makeNewBearerToken(configuration: configuration)
         self.updateTask = eventLoop.scheduleRepeatedTask(initialDelay: .minutes(55), delay: .minutes(55)) { task in
-            self.configuration.logger?.debug("Creating a new APNS token because old one expired", metadata: ["origin": "APNSwift"])
+            self.configuration.logger?.debug("Creating a new APNS token because old one expired")
             self.currentBearerToken = try APNSwiftBearerTokenFactory.makeNewBearerToken(configuration: configuration)
         }
     }
@@ -39,7 +39,7 @@ internal final class APNSwiftBearerTokenFactory {
         self.cancelled = true
         self.updateTask?.cancel()
         self.updateTask = nil
-        self.configuration.logger?.debug("Destroying APNS bearer token", metadata: ["origin": "APNSwift"])
+        self.configuration.logger?.debug("Destroying APNS bearer token")
     }
 
     deinit {

--- a/Sources/APNSwift/APNSwiftBearerTokenFactory.swift
+++ b/Sources/APNSwift/APNSwiftBearerTokenFactory.swift
@@ -26,10 +26,10 @@ internal final class APNSwiftBearerTokenFactory {
         self.eventLoop = eventLoop
         self.eventLoop.assertInEventLoop()
         self.configuration = configuration
-        self.configuration.logger.info("Token - making new token")
+        self.configuration.logger?.debug("Creating a new APNS token", metadata: ["origin": "APNSwift"])
         self.currentBearerToken = try APNSwiftBearerTokenFactory.makeNewBearerToken(configuration: configuration)
         self.updateTask = eventLoop.scheduleRepeatedTask(initialDelay: .minutes(55), delay: .minutes(55)) { task in
-            self.configuration.logger.info("Token - updating token")
+            self.configuration.logger?.debug("Creating a new APNS token because old one expired", metadata: ["origin": "APNSwift"])
             self.currentBearerToken = try APNSwiftBearerTokenFactory.makeNewBearerToken(configuration: configuration)
         }
     }
@@ -39,7 +39,7 @@ internal final class APNSwiftBearerTokenFactory {
         self.cancelled = true
         self.updateTask?.cancel()
         self.updateTask = nil
-        self.configuration.logger.info("Token - killed")
+        self.configuration.logger?.debug("Destroying APNS bearer token", metadata: ["origin": "APNSwift"])
     }
 
     deinit {

--- a/Sources/APNSwift/APNSwiftConfiguration.swift
+++ b/Sources/APNSwift/APNSwiftConfiguration.swift
@@ -57,7 +57,7 @@ public struct APNSwiftConfiguration {
          signingMode: .file(path: "/Users/kylebrowning/Downloads/AuthKey_9UC9ZLQ8YW.p8"),
          topic: "com.grasscove.Fern",
          environment: .sandbox,
-         loggerType: logger)
+         logger: logger)
      )
      ````
      */

--- a/Sources/APNSwift/APNSwiftConfiguration.swift
+++ b/Sources/APNSwift/APNSwiftConfiguration.swift
@@ -26,7 +26,7 @@ public struct APNSwiftConfiguration {
     public var topic: String
     public var environment: Environment
     public var tlsConfiguration: TLSConfiguration
-    internal var logger: Logger
+    internal var logger: Logger?
 
     public var url: URL {
         switch environment {
@@ -48,7 +48,7 @@ public struct APNSwiftConfiguration {
      `file`, `data`, or `custom`.
        - topic: The bundle identifier for these push notifications.
        - environment: The environment to use, sandbox, or production.
-       - loggerType: The logger you wish to use, .createDefault, or .custom(Logger)
+       - logger: The logger you wish to use, if nil, one will be created
 
      ### Usage Example: ###
      ````
@@ -57,27 +57,26 @@ public struct APNSwiftConfiguration {
          signingMode: .file(path: "/Users/kylebrowning/Downloads/AuthKey_9UC9ZLQ8YW.p8"),
          topic: "com.grasscove.Fern",
          environment: .sandbox,
-         loggerType: .custom(logger)
+         loggerType: logger)
      )
      ````
      */
     public init(keyIdentifier: String, teamIdentifier: String, signer: APNSwiftSigner, topic: String, environment: APNSwiftConfiguration.Environment) {
-        self.init(keyIdentifier: keyIdentifier, teamIdentifier: teamIdentifier, signer: signer, topic: topic, environment: environment, loggerType: .createDefault)
+        self.init(keyIdentifier: keyIdentifier, teamIdentifier: teamIdentifier, signer: signer, topic: topic, environment: environment, logger: nil)
     }
     
-    public init(keyIdentifier: String, teamIdentifier: String, signer: APNSwiftSigner, topic: String, environment: APNSwiftConfiguration.Environment, loggerType: LoggerType = .createDefault) {
+    public init(keyIdentifier: String, teamIdentifier: String, signer: APNSwiftSigner, topic: String, environment: APNSwiftConfiguration.Environment, logger: Logger? = nil) {
         self.keyIdentifier = keyIdentifier
         self.teamIdentifier = teamIdentifier
         self.topic = topic
         self.signer = signer
         self.environment = environment
         self.tlsConfiguration = TLSConfiguration.forClient(applicationProtocols: ["h2"])
-        switch loggerType {
-        case .createDefault:
-            self.logger = Logger(label: "com.apnswift")
-            logger.logLevel = .critical
-        case .custom (let logger):
+        
+        if let logger = logger {
             self.logger = logger
+        } else {
+            self.logger = Logger(label: "com.apnswift")
         }
     }
 }
@@ -89,12 +88,6 @@ extension APNSwiftConfiguration {
     }
 }
 
-extension APNSwiftConfiguration {
-    public enum LoggerType {
-        case createDefault
-        case custom(Logger)
-    }
-}
 
 extension APNSwiftConnection {
     public enum PushType: String {

--- a/Sources/APNSwift/APNSwiftConfiguration.swift
+++ b/Sources/APNSwift/APNSwiftConfiguration.swift
@@ -73,10 +73,9 @@ public struct APNSwiftConfiguration {
         self.environment = environment
         self.tlsConfiguration = TLSConfiguration.forClient(applicationProtocols: ["h2"])
         
-        if let logger = logger {
+        if var logger = logger {
+            logger[metadataKey: "origin"] = "APNSwift"
             self.logger = logger
-        } else {
-            self.logger = Logger(label: "com.apnswift")
         }
     }
 }

--- a/Sources/APNSwift/APNSwiftConfiguration.swift
+++ b/Sources/APNSwift/APNSwiftConfiguration.swift
@@ -48,7 +48,7 @@ public struct APNSwiftConfiguration {
      `file`, `data`, or `custom`.
        - topic: The bundle identifier for these push notifications.
        - environment: The environment to use, sandbox, or production.
-       - logger: a logger for debugging/monitoring purposes
+       - loggerType: The logger you wish to use, .createDefault, or .custom(Logger)
 
      ### Usage Example: ###
      ````
@@ -57,7 +57,7 @@ public struct APNSwiftConfiguration {
          signingMode: .file(path: "/Users/kylebrowning/Downloads/AuthKey_9UC9ZLQ8YW.p8"),
          topic: "com.grasscove.Fern",
          environment: .sandbox,
-         logger:
+         loggerType: .custom(logger)
      )
      ````
      */

--- a/Sources/APNSwift/APNSwiftConnection.swift
+++ b/Sources/APNSwift/APNSwiftConnection.swift
@@ -82,7 +82,7 @@ public final class APNSwiftConnection {
     
     public static func connect(configuration: APNSwiftConfiguration, on eventLoop: EventLoop) -> EventLoopFuture<APNSwiftConnection> {
         struct UnsupportedServerPushError: Error {}
-        configuration.logger?.info("Connection - starting", metadata: ["origin": "APNSwift"])
+        configuration.logger?.info("Connection - starting")
         let sslContext = try! NIOSSLContext(configuration: configuration.tlsConfiguration)
         let connectionFullyUpPromise = eventLoop.makePromise(of: Void.self)
         let tcpConnection = ClientBootstrap(group: eventLoop).connect(host: configuration.url.host!, port: 443)
@@ -94,24 +94,24 @@ public final class APNSwiftConnection {
                                                  WaitForTLSUpHandler(allDonePromise: connectionFullyUpPromise)]).flatMap {
                 channel.configureHTTP2Pipeline(mode: .client) { channel, _ in
                     let error = UnsupportedServerPushError()
-                    configuration.logger?.warning("Connection - failed \(error)", metadata: ["origin": "APNSwift"])
+                    configuration.logger?.warning("Connection - failed \(error)")
                     return channel.eventLoop.makeFailedFuture(error)
                 }.flatMap { multiplexer in
                     var tokenFactory: APNSwiftBearerTokenFactory? = nil
-                    configuration.logger?.debug("Connection - token factory setup", metadata: ["origin": "APNSwift"])
+                    configuration.logger?.debug("Connection - token factory setup")
                     if configuration.tlsConfiguration.privateKey == nil {
                         do {
                             tokenFactory = try APNSwiftBearerTokenFactory(eventLoop: eventLoop, configuration: configuration)
-                            configuration.logger?.debug("Connection - token factory created", metadata: ["origin": "APNSwift"])
+                            configuration.logger?.debug("Connection - token factory created")
                         } catch {
-                            configuration.logger?.debug("Connection - token factory setup failed", metadata: ["origin": "APNSwift"])
+                            configuration.logger?.debug("Connection - token factory setup failed")
                             return channel.eventLoop.makeFailedFuture(APNSwiftError.SigningError.invalidSignatureData)
                         }
                     } else {
-                        configuration.logger?.debug("Connection - private key empty, using pem", metadata: ["origin": "APNSwift"])
+                        configuration.logger?.debug("Connection - private key empty, using pem")
                     }
                     return connectionFullyUpPromise.futureResult.map { () -> APNSwiftConnection in
-                        configuration.logger?.debug("Connection - bringing up", metadata: ["origin": "APNSwift"])
+                        configuration.logger?.debug("Connection - bringing up")
                         return APNSwiftConnection(channel: channel, multiplexer: multiplexer, configuration: configuration, bearerTokenFactory: tokenFactory)
                     }
                 }
@@ -129,7 +129,7 @@ public final class APNSwiftConnection {
         self.multiplexer = multiplexer
         self.configuration = configuration
         self.bearerTokenFactory = bearerTokenFactory
-        configuration.logger?.info("APNSwift Connection - up", metadata: ["origin": "APNSwift"])
+        configuration.logger?.info("APNSwift Connection - up")
     }
     
     @available(*, deprecated, message: "APNSwiftConnection is initialized internally now.")
@@ -172,7 +172,7 @@ public final class APNSwiftConnection {
     /// This is to be used with caution. APNSwift cannot gurantee delivery if you do not have the correct payload.
     /// For more information see: [Creating APN Payload](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html)
     public func send(rawBytes payload: ByteBuffer, pushType: APNSwiftConnection.PushType, to deviceToken: String, expiration: Date? = nil, priority: Int? = nil, collapseIdentifier: String? = nil, topic: String? = nil) -> EventLoopFuture<Void> {
-            configuration.logger?.debug("Send - starting up", metadata: ["origin": "APNSwift"])
+            configuration.logger?.debug("Send - starting up")
             let streamPromise = channel.eventLoop.makePromise(of: Channel.self)
             multiplexer.createStreamChannel(promise: streamPromise) { channel, streamID in
                 let handlers: [ChannelHandler] = [
@@ -191,7 +191,7 @@ public final class APNSwiftConnection {
             )
             
             return streamPromise.futureResult.flatMap { stream in
-                self.configuration.logger?.info("Send - sending", metadata: ["origin": "APNSwift"])
+                self.configuration.logger?.info("Send - sending")
                 return stream.writeAndFlush(context)
             }.flatMap {
                 responsePromise.futureResult
@@ -203,12 +203,12 @@ public final class APNSwiftConnection {
     }
     
     var onClose: EventLoopFuture<Void> {
-        configuration.logger?.debug("Connection - closed", metadata: ["origin": "APNSwift"])
+        configuration.logger?.debug("Connection - closed")
         return channel.closeFuture
     }
     
     public func close() -> EventLoopFuture<Void> {
-        configuration.logger?.debug("Connection - closing", metadata: ["origin": "APNSwift"])
+        configuration.logger?.debug("Connection - closing")
         channel.eventLoop.execute {
             self.configuration.logger?.debug("Connection - killing bearerToken")
             self.bearerTokenFactory?.cancel()

--- a/Sources/APNSwift/APNSwiftConnection.swift
+++ b/Sources/APNSwift/APNSwiftConnection.swift
@@ -82,7 +82,7 @@ public final class APNSwiftConnection {
     
     public static func connect(configuration: APNSwiftConfiguration, on eventLoop: EventLoop) -> EventLoopFuture<APNSwiftConnection> {
         struct UnsupportedServerPushError: Error {}
-        configuration.logger?.info("Connection - starting")
+        configuration.logger?.debug("Connection - starting")
         let sslContext = try! NIOSSLContext(configuration: configuration.tlsConfiguration)
         let connectionFullyUpPromise = eventLoop.makePromise(of: Void.self)
         let tcpConnection = ClientBootstrap(group: eventLoop).connect(host: configuration.url.host!, port: 443)
@@ -129,7 +129,7 @@ public final class APNSwiftConnection {
         self.multiplexer = multiplexer
         self.configuration = configuration
         self.bearerTokenFactory = bearerTokenFactory
-        configuration.logger?.info("APNSwift Connection - up")
+        configuration.logger?.info("Connection - up")
     }
     
     @available(*, deprecated, message: "APNSwiftConnection is initialized internally now.")

--- a/Sources/APNSwift/APNSwiftConnection.swift
+++ b/Sources/APNSwift/APNSwiftConnection.swift
@@ -82,7 +82,7 @@ public final class APNSwiftConnection {
     
     public static func connect(configuration: APNSwiftConfiguration, on eventLoop: EventLoop) -> EventLoopFuture<APNSwiftConnection> {
         struct UnsupportedServerPushError: Error {}
-
+        configuration.logger.info("Connection - starting")
         let sslContext = try! NIOSSLContext(configuration: configuration.tlsConfiguration)
         let connectionFullyUpPromise = eventLoop.makePromise(of: Void.self)
         let tcpConnection = ClientBootstrap(group: eventLoop).connect(host: configuration.url.host!, port: 443)
@@ -93,17 +93,25 @@ public final class APNSwiftConnection {
             return channel.pipeline.addHandlers([sslHandler,
                                                  WaitForTLSUpHandler(allDonePromise: connectionFullyUpPromise)]).flatMap {
                 channel.configureHTTP2Pipeline(mode: .client) { channel, _ in
-                    return channel.eventLoop.makeFailedFuture(UnsupportedServerPushError())
+                    let error = UnsupportedServerPushError()
+                    configuration.logger.info("Connection - failed \(error.localizedDescription)")
+                    return channel.eventLoop.makeFailedFuture(error)
                 }.flatMap { multiplexer in
                     var tokenFactory: APNSwiftBearerTokenFactory? = nil
+                    configuration.logger.info("Connection - token factory setup")
                     if configuration.tlsConfiguration.privateKey == nil {
                         do {
                             tokenFactory = try APNSwiftBearerTokenFactory(eventLoop: eventLoop, configuration: configuration)
+                            configuration.logger.info("Connection - token factory created")
                         } catch {
+                            configuration.logger.info("Connection - token factory setup failed")
                             return channel.eventLoop.makeFailedFuture(APNSwiftError.SigningError.invalidSignatureData)
                         }
+                    } else {
+                        configuration.logger.info("Connection - private key empty, using pem")
                     }
                     return connectionFullyUpPromise.futureResult.map { () -> APNSwiftConnection in
+                        configuration.logger.info("Connection - bringing up")
                         return APNSwiftConnection(channel: channel, multiplexer: multiplexer, configuration: configuration, bearerTokenFactory: tokenFactory)
                     }
                 }
@@ -121,6 +129,7 @@ public final class APNSwiftConnection {
         self.multiplexer = multiplexer
         self.configuration = configuration
         self.bearerTokenFactory = bearerTokenFactory
+        configuration.logger.info("Connection: up")
     }
     
     @available(*, deprecated, message: "APNSwiftConnection is initialized internally now.")
@@ -163,13 +172,14 @@ public final class APNSwiftConnection {
     /// This is to be used with caution. APNSwift cannot gurantee delivery if you do not have the correct payload.
     /// For more information see: [Creating APN Payload](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html)
     public func send(rawBytes payload: ByteBuffer, pushType: APNSwiftConnection.PushType, to deviceToken: String, expiration: Date? = nil, priority: Int? = nil, collapseIdentifier: String? = nil, topic: String? = nil) -> EventLoopFuture<Void> {
+            configuration.logger.info("Send - starting up")
             let streamPromise = channel.eventLoop.makePromise(of: Channel.self)
             multiplexer.createStreamChannel(promise: streamPromise) { channel, streamID in
                 let handlers: [ChannelHandler] = [
                     HTTP2ToHTTP1ClientCodec(streamID: streamID, httpProtocol: .https),
                     APNSwiftRequestEncoder(deviceToken: deviceToken, configuration: self.configuration, bearerToken: self.bearerTokenFactory?.currentBearerToken, pushType: pushType, expiration: expiration, priority: priority, collapseIdentifier: collapseIdentifier, topic: topic),
                     APNSwiftResponseDecoder(),
-                    APNSwiftStreamHandler(),
+                    APNSwiftStreamHandler(configuration: self.configuration),
                 ]
                 return channel.pipeline.addHandlers(handlers)
             }
@@ -181,6 +191,7 @@ public final class APNSwiftConnection {
             )
             
             return streamPromise.futureResult.flatMap { stream in
+                self.configuration.logger.info("Send - sending")
                 return stream.writeAndFlush(context)
             }.flatMap {
                 responsePromise.futureResult
@@ -192,11 +203,14 @@ public final class APNSwiftConnection {
     }
     
     var onClose: EventLoopFuture<Void> {
+        configuration.logger.info("Connection - closed")
         return channel.closeFuture
     }
     
     public func close() -> EventLoopFuture<Void> {
+        configuration.logger.info("Connection - closing")
         channel.eventLoop.execute {
+            self.configuration.logger.info("Connection - killing bearerToken")
             self.bearerTokenFactory?.cancel()
             self.bearerTokenFactory = nil
         }

--- a/Sources/APNSwift/APNSwiftRequestEncoder.swift
+++ b/Sources/APNSwift/APNSwiftRequestEncoder.swift
@@ -53,6 +53,7 @@ internal final class APNSwiftRequestEncoder: ChannelOutboundHandler {
 
     /// See `ChannelOutboundHandler.write(context:data:promise:)`.
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        self.configuration.logger.info("Request - building")
         let buffer: ByteBuffer = unwrapOutboundIn(data)
         var reqHead = HTTPRequestHead(version: .init(major: 2, minor: 0), method: .POST, uri: "/3/device/\(deviceToken)")
         reqHead.headers.add(name: "content-type", value: "application/json")
@@ -81,9 +82,10 @@ internal final class APNSwiftRequestEncoder: ChannelOutboundHandler {
         if let bearerToken = self.bearerToken {
             reqHead.headers.add(name: "authorization", value: "bearer \(bearerToken)")
         }
-
+        self.configuration.logger.info("Request - built")
         context.write(wrapOutboundOut(.head(reqHead))).cascadeFailure(to: promise)
         context.write(wrapOutboundOut(.body(.byteBuffer(buffer)))).cascadeFailure(to: promise)
         context.write(wrapOutboundOut(.end(nil)), promise: promise)
+        self.configuration.logger.info("Request - sent")
     }
 }

--- a/Sources/APNSwift/APNSwiftRequestEncoder.swift
+++ b/Sources/APNSwift/APNSwiftRequestEncoder.swift
@@ -53,7 +53,7 @@ internal final class APNSwiftRequestEncoder: ChannelOutboundHandler {
 
     /// See `ChannelOutboundHandler.write(context:data:promise:)`.
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        self.configuration.logger?.debug("Request - building", metadata: ["origin": "APNSwift"])
+        self.configuration.logger?.debug("Request - building")
         let buffer: ByteBuffer = unwrapOutboundIn(data)
         var reqHead = HTTPRequestHead(version: .init(major: 2, minor: 0), method: .POST, uri: "/3/device/\(deviceToken)")
         reqHead.headers.add(name: "content-type", value: "application/json")
@@ -82,10 +82,10 @@ internal final class APNSwiftRequestEncoder: ChannelOutboundHandler {
         if let bearerToken = self.bearerToken {
             reqHead.headers.add(name: "authorization", value: "bearer \(bearerToken)")
         }
-        self.configuration.logger?.trace("Request - built", metadata: ["origin": "APNSwift"])
+        self.configuration.logger?.trace("Request - built")
         context.write(wrapOutboundOut(.head(reqHead))).cascadeFailure(to: promise)
         context.write(wrapOutboundOut(.body(.byteBuffer(buffer)))).cascadeFailure(to: promise)
         context.write(wrapOutboundOut(.end(nil)), promise: promise)
-        self.configuration.logger?.trace("Request - sent", metadata: ["origin": "APNSwift"])
+        self.configuration.logger?.trace("Request - sent")
     }
 }

--- a/Sources/APNSwift/APNSwiftRequestEncoder.swift
+++ b/Sources/APNSwift/APNSwiftRequestEncoder.swift
@@ -53,7 +53,7 @@ internal final class APNSwiftRequestEncoder: ChannelOutboundHandler {
 
     /// See `ChannelOutboundHandler.write(context:data:promise:)`.
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
-        self.configuration.logger.info("Request - building")
+        self.configuration.logger?.debug("Request - building", metadata: ["origin": "APNSwift"])
         let buffer: ByteBuffer = unwrapOutboundIn(data)
         var reqHead = HTTPRequestHead(version: .init(major: 2, minor: 0), method: .POST, uri: "/3/device/\(deviceToken)")
         reqHead.headers.add(name: "content-type", value: "application/json")
@@ -82,10 +82,10 @@ internal final class APNSwiftRequestEncoder: ChannelOutboundHandler {
         if let bearerToken = self.bearerToken {
             reqHead.headers.add(name: "authorization", value: "bearer \(bearerToken)")
         }
-        self.configuration.logger.info("Request - built")
+        self.configuration.logger?.trace("Request - built", metadata: ["origin": "APNSwift"])
         context.write(wrapOutboundOut(.head(reqHead))).cascadeFailure(to: promise)
         context.write(wrapOutboundOut(.body(.byteBuffer(buffer)))).cascadeFailure(to: promise)
         context.write(wrapOutboundOut(.end(nil)), promise: promise)
-        self.configuration.logger.info("Request - sent")
+        self.configuration.logger?.trace("Request - sent", metadata: ["origin": "APNSwift"])
     }
 }

--- a/Sources/APNSwift/APNSwiftStreamHandler.swift
+++ b/Sources/APNSwift/APNSwiftStreamHandler.swift
@@ -32,24 +32,24 @@ final class APNSwiftStreamHandler: ChannelDuplexHandler {
     }
 
     func channelRead(context _: ChannelHandlerContext, data: NIOAny) {
-        self.configuration?.logger.info("Response - received")
+        self.configuration?.logger?.debug("Response - received", metadata: ["origin": "APNSwift"])
         let res = unwrapInboundIn(data)
         guard let current = self.queue.popLast() else { return }
         guard res.header.status == .ok else {
             guard let buffer = res.byteBuffer else {
-                self.configuration?.logger.info("Response - no response body")
+                self.configuration?.logger?.warning("Response - no response body", metadata: ["origin": "APNSwift"])
                 return current.responsePromise.fail(NoResponseBodyFromApple())
             }
             do {
                 let error = try JSONDecoder().decode(APNSwiftError.ResponseStruct.self, from: buffer)
-                self.configuration?.logger.info("Response - bad request \(error.reason)")
+                self.configuration?.logger?.warning("Response - bad request \(error.reason)", metadata: ["origin": "APNSwift"])
                 return current.responsePromise.fail(APNSwiftError.ResponseError.badRequest(error.reason))
             } catch {
-                self.configuration?.logger.info("Response - failed \(error.localizedDescription)")
+                self.configuration?.logger?.warning("Response - failed \(error.localizedDescription)", metadata: ["origin": "APNSwift"])
                 return current.responsePromise.fail(error)
             }
         }
-        self.configuration?.logger.info("Response - successful")
+        self.configuration?.logger?.info("Response - successful", metadata: ["origin": "APNSwift"])
         current.responsePromise.succeed(Void())
     }
 

--- a/Sources/APNSwift/APNSwiftStreamHandler.swift
+++ b/Sources/APNSwift/APNSwiftStreamHandler.swift
@@ -32,24 +32,24 @@ final class APNSwiftStreamHandler: ChannelDuplexHandler {
     }
 
     func channelRead(context _: ChannelHandlerContext, data: NIOAny) {
-        self.configuration?.logger?.debug("Response - received", metadata: ["origin": "APNSwift"])
+        self.configuration?.logger?.debug("Response - received")
         let res = unwrapInboundIn(data)
         guard let current = self.queue.popLast() else { return }
         guard res.header.status == .ok else {
             guard let buffer = res.byteBuffer else {
-                self.configuration?.logger?.warning("Response - no response body", metadata: ["origin": "APNSwift"])
+                self.configuration?.logger?.warning("Response - no response body")
                 return current.responsePromise.fail(NoResponseBodyFromApple())
             }
             do {
                 let error = try JSONDecoder().decode(APNSwiftError.ResponseStruct.self, from: buffer)
-                self.configuration?.logger?.warning("Response - bad request \(error.reason)", metadata: ["origin": "APNSwift"])
+                self.configuration?.logger?.warning("Response - bad request \(error.reason)")
                 return current.responsePromise.fail(APNSwiftError.ResponseError.badRequest(error.reason))
             } catch {
-                self.configuration?.logger?.warning("Response - failed \(error.localizedDescription)", metadata: ["origin": "APNSwift"])
+                self.configuration?.logger?.warning("Response - failed \(error.localizedDescription)")
                 return current.responsePromise.fail(error)
             }
         }
-        self.configuration?.logger?.info("Response - successful", metadata: ["origin": "APNSwift"])
+        self.configuration?.logger?.info("Response - successful")
         current.responsePromise.succeed(Void())
     }
 

--- a/Sources/APNSwift/APNSwiftStreamHandler.swift
+++ b/Sources/APNSwift/APNSwiftStreamHandler.swift
@@ -24,25 +24,32 @@ final class APNSwiftStreamHandler: ChannelDuplexHandler {
     typealias OutboundIn = APNSwiftRequestContext
 
     var queue: [APNSwiftRequestContext]
-
-    init() {
+    let configuration: APNSwiftConfiguration?
+    
+    init(configuration: APNSwiftConfiguration? = nil) {
         queue = []
+        self.configuration = configuration
     }
 
     func channelRead(context _: ChannelHandlerContext, data: NIOAny) {
+        self.configuration?.logger.info("Response - received")
         let res = unwrapInboundIn(data)
         guard let current = self.queue.popLast() else { return }
         guard res.header.status == .ok else {
             guard let buffer = res.byteBuffer else {
+                self.configuration?.logger.info("Response - no response body")
                 return current.responsePromise.fail(NoResponseBodyFromApple())
             }
             do {
                 let error = try JSONDecoder().decode(APNSwiftError.ResponseStruct.self, from: buffer)
+                self.configuration?.logger.info("Response - bad request \(error.reason)")
                 return current.responsePromise.fail(APNSwiftError.ResponseError.badRequest(error.reason))
             } catch {
+                self.configuration?.logger.info("Response - failed \(error.localizedDescription)")
                 return current.responsePromise.fail(error)
             }
         }
+        self.configuration?.logger.info("Response - successful")
         current.responsePromise.succeed(Void())
     }
 

--- a/Sources/APNSwiftExample/main.swift
+++ b/Sources/APNSwiftExample/main.swift
@@ -27,13 +27,13 @@ let signer = try! APNSwiftSigner(filePath: "/Users/kylebrowning/Desktop/AuthKey_
 
 // optional
 var logger = Logger(label: "com.apnswift")
-logger.logLevel = .info
+logger.logLevel = .debug
 let apnsConfig = APNSwiftConfiguration(keyIdentifier: "9UC9ZLQ8YW",
                                        teamIdentifier: "ABBM6U9RM5",
                                        signer: signer,
                                        topic: "com.grasscove.Fern",
                                        environment: .sandbox,
-                                       loggerType: .custom(logger))
+                                       logger: logger)
 
 
 let apns = try APNSwiftConnection.connect(configuration: apnsConfig, on: group.next()).wait()

--- a/Sources/APNSwiftExample/main.swift
+++ b/Sources/APNSwiftExample/main.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Logging
 import NIO
 import APNSwift
 import NIOHTTP1
@@ -24,11 +25,16 @@ var verbose = true
 
 let signer = try! APNSwiftSigner(filePath: "/Users/kylebrowning/Desktop/AuthKey_9UC9ZLQ8YW.p8")
 
+// optional
+var logger = Logger(label: "com.apnswift")
+logger.logLevel = .info
 let apnsConfig = APNSwiftConfiguration(keyIdentifier: "9UC9ZLQ8YW",
                                        teamIdentifier: "ABBM6U9RM5",
                                        signer: signer,
                                        topic: "com.grasscove.Fern",
-                                       environment: .sandbox)
+                                       environment: .sandbox,
+                                       loggerType: .custom(logger))
+
 
 let apns = try APNSwiftConnection.connect(configuration: apnsConfig, on: group.next()).wait()
 


### PR DESCRIPTION
# Example
```
2019-11-27T08:26:29-0800 info: Connection - starting
2019-11-27T08:26:29-0800 info: Connection - token factory setup
2019-11-27T08:26:29-0800 info: Token - making new token
2019-11-27T08:26:29-0800 info: Connection - token factory created
2019-11-27T08:26:29-0800 info: Connection - bringing up
2019-11-27T08:26:29-0800 info: Connection: up
* Connected to api.development.push.apple.com ([IPv4]17.188.138.73/17.188.138.73:443
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:29-0800 info: Response - received
2019-11-27T08:26:29-0800 info: Response - successful
2019-11-27T08:26:29-0800 info: Send - starting up
2019-11-27T08:26:29-0800 info: Send - sending
2019-11-27T08:26:29-0800 info: Request - building
2019-11-27T08:26:29-0800 info: Request - built
2019-11-27T08:26:29-0800 info: Request - sent
2019-11-27T08:26:30-0800 info: Response - received
2019-11-27T08:26:30-0800 info: Response - successful
2019-11-27T08:26:30-0800 info: Send - starting up
2019-11-27T08:26:30-0800 info: Send - sending
2019-11-27T08:26:30-0800 info: Request - building
2019-11-27T08:26:30-0800 info: Request - built
2019-11-27T08:26:30-0800 info: Request - sent
2019-11-27T08:26:30-0800 info: Response - received
2019-11-27T08:26:30-0800 info: Response - successful
2019-11-27T08:26:30-0800 info: Send - starting up
2019-11-27T08:26:30-0800 info: Send - sending
2019-11-27T08:26:30-0800 info: Request - building
2019-11-27T08:26:30-0800 info: Request - built
2019-11-27T08:26:30-0800 info: Request - sent
2019-11-27T08:26:30-0800 info: Response - received
2019-11-27T08:26:30-0800 info: Response - successful
2019-11-27T08:26:30-0800 info: Send - starting up
2019-11-27T08:26:30-0800 info: Send - sending
2019-11-27T08:26:30-0800 info: Request - building
2019-11-27T08:26:30-0800 info: Request - built
2019-11-27T08:26:30-0800 info: Request - sent
2019-11-27T08:26:30-0800 info: Response - received
2019-11-27T08:26:30-0800 info: Response - successful
2019-11-27T08:26:30-0800 info: Send - starting up
2019-11-27T08:26:30-0800 info: Send - sending
2019-11-27T08:26:30-0800 info: Request - building
2019-11-27T08:26:30-0800 info: Request - built
2019-11-27T08:26:30-0800 info: Request - sent
2019-11-27T08:26:31-0800 info: Response - received
2019-11-27T08:26:31-0800 info: Response - successful
2019-11-27T08:26:31-0800 info: Connection - closing
2019-11-27T08:26:31-0800 info: Connection - killing bearerToken
2019-11-27T08:26:31-0800 info: Token - killed
```