### PR TITLE
use openssl@1.1 on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             pkgConfig: "openssl",
             providers: [
                 .apt(["openssl libssl-dev"]),
-                .brew(["openssl"]),
+                .brew(["openssl@1.1"]),
             ]
         ),
 


### PR DESCRIPTION
`brew install openssl` now installs openssl@1.1 and there is no way to install openssl 1.0 or rename openssl@1.1 to openssl.