### PR TITLE
Make APNSwiftPayload naming more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,19 @@ let apnsConfig = ...
 let apns = try APNSwiftConnection.connect(configuration: apnsConfig, on: group.next()).wait()
 ```
 
-### Alert
+### APNSwiftAlert
 
-[`Alert`](https://github.com/kylebrowning/swift-nio-http2-apns/blob/master/Sources/APNSwift/APNSRequest.swift) is the actual meta data of the push notification alert someone wishes to send. More details on the specifics of each property are provided [here](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html). They follow a 1-1 naming scheme listed in Apple's documentation
+[`APNSwiftAlert`](https://github.com/kylebrowning/APNSwift/blob/tn-concise-naming/Sources/APNSwift/APNSwiftAlert.swift) is the actual meta data of the push notification alert someone wishes to send. More details on the specifics of each property are provided [here](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html). They follow a 1-1 naming scheme listed in Apple's documentation
 
 
-#### Example `Alert`
+#### Example `APNSwiftAlert`
 ```swift
-let alert = Alert(title: "Hey There", subtitle: "Full moon sighting", body: "There was a full moon last night did you see it")
+let alert = APNSwiftAlert(title: "Hey There", subtitle: "Full moon sighting", body: "There was a full moon last night did you see it")
 ```
 
 ### APNSwiftPayload
 
-[`APNSwiftPayload`](https://github.com/kylebrowning/APNSwift/blob/master/Sources/APNSwift/APNSwiftRequest.swift#L25) is the meta data of the push notification. Things like the alert, badge count. More details on the specifics of each property are provided [here](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html). They follow a 1-1 naming scheme listed in Apple's documentation
+[`APNSwiftPayload`](https://github.com/kylebrowning/APNSwift/blob/tn-concise-naming/Sources/APNSwift/APNSwiftPayload.swift) is the meta data of the push notification. Things like the alert, badge count. More details on the specifics of each property are provided [here](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html). They follow a 1-1 naming scheme listed in Apple's documentation
 
 
 #### Example `APNSwiftPayload`
@@ -139,10 +139,13 @@ var apnsConfig = try APNSwiftConfiguration(
 )
 let apns = try APNSwiftConnection.connect(configuration: apnsConfig, on: group.next()).wait()
 ```
+
 ### Need a completely custom arbtirary payload and dont like being typecast?
+
 APNSwift provides the ability to send raw payloads. You can use `Data`, `ByteBuffer`, `DispatchData`, `Array`
 Though this is to be used with caution. APNSwift cannot gurantee delivery if you do not have the correct payload.
 For more information see: [Creating APN Payload](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html)
+
 ```swift
 let notificationJsonPayload = ...
 let data: Data = try! encoder.encode(notificationJsonPayload)

--- a/Sources/APNSwift/APNSwiftAlert.swift
+++ b/Sources/APNSwift/APNSwiftAlert.swift
@@ -1,0 +1,62 @@
+/// This structure provides the data structure for an APNS Alert
+public struct APNSwiftAlert: Codable {
+    public let title: String?
+    public let subtitle: String?
+    public let body: String?
+    public let titleLocKey: String?
+    public let titleLocArgs: [String]?
+    public let actionLocKey: String?
+    public let locKey: String?
+    public let locArgs: [String]?
+    public let launchImage: String?
+
+    /**
+     This structure provides the data structure for an APNS Alert
+     - Parameter title: The title to be displayed to the user.
+     - Parameter subtitle: The subtitle to be displayed to the user.
+     - Parameter body: The body of the push notification.
+     - Parameter titleLocKey: The key to a title string in the Localizable.strings file for the current
+     localization.
+     - Parameter titleLocArgs: Variable string values to appear in place of the format specifiers in
+     title-loc-key.
+     - Parameter actionLocKey: The string is used as a key to get a localized string in the current localization
+     to use for the right button’s title instead of “View”.
+     - Parameter locKey: A key to an alert-message string in a Localizable.strings file for the current
+     localization (which is set by the user’s language preference).
+     - Parameter locArgs: Variable string values to appear in place of the format specifiers in loc-key.
+     - Parameter launchImage: The filename of an image file in the app bundle, with or without the filename
+     extension.
+
+     For more information see:
+     [Payload Key Reference](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#)
+     ### Usage Example: ###
+     ````
+     let alert = Alert(title: "Hey There", subtitle: "Subtitle", body: "Body")
+     ````
+     */
+    public init(title: String? = nil, subtitle: String? = nil, body: String? = nil,
+                titleLocKey: String? = nil, titleLocArgs: [String]? = nil, actionLocKey: String? = nil,
+                locKey: String? = nil, locArgs: [String]? = nil, launchImage: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+        self.titleLocKey = titleLocKey
+        self.titleLocArgs = titleLocArgs
+        self.actionLocKey = actionLocKey
+        self.locKey = locKey
+        self.locArgs = locArgs
+        self.launchImage = launchImage
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case subtitle
+        case body
+        case titleLocKey = "title-loc-key"
+        case titleLocArgs = "title-loc-args"
+        case actionLocKey = "action-loc-key"
+        case locKey = "loc-key"
+        case locArgs = "loc-args"
+        case launchImage = "launch-image"
+    }
+}

--- a/Sources/APNSwift/APNSwiftAlert.swift
+++ b/Sources/APNSwift/APNSwiftAlert.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2020 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 /// This structure provides the data structure for an APNS Alert
 public struct APNSwiftAlert: Codable {
     public let title: String?

--- a/Sources/APNSwift/APNSwiftClient.swift
+++ b/Sources/APNSwift/APNSwiftClient.swift
@@ -37,7 +37,7 @@ extension APNSwiftClient {
      try apns.send(notification, pushType: .alert, to: "b27a07be2092c7fbb02ab5f62f3135c615e18acc0ddf39a30ffde34d41665276", with: JSONEncoder(), expiration: expiry, priority: 10, collapseIdentifier: "huro2").wait()
      ```
      */
-    public func send(_ alert: APNSwiftPayload.APNSwiftAlert,
+    public func send(_ alert: APNSwiftAlert,
                      pushType: APNSwiftConnection.PushType = .alert,
                      to deviceToken: String,
                      with encoder: JSONEncoder = JSONEncoder(),

--- a/Sources/APNSwift/APNSwiftClient.swift
+++ b/Sources/APNSwift/APNSwiftClient.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2019-2020 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import Foundation
 import Logging
 import NIO

--- a/Sources/APNSwift/APNSwiftConnection.swift
+++ b/Sources/APNSwift/APNSwiftConnection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the APNSwift open source project
 //
-// Copyright (c) 2019 the APNSwift project authors
+// Copyright (c) 2019-2020 the APNSwift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/APNSwift/APNSwiftConnection.swift
+++ b/Sources/APNSwift/APNSwiftConnection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the APNSwift open source project
 //
-// Copyright (c) 2019-2020 the APNSwift project authors
+// Copyright (c) 2019 the APNSwift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/APNSwift/APNSwiftNotification.swift
+++ b/Sources/APNSwift/APNSwiftNotification.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2020 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// This is a protocol which allows developers to construct their own Notification payload
+public protocol APNSwiftNotification: Encodable {
+    var aps: APNSwiftPayload { get }
+}

--- a/Sources/APNSwift/APNSwiftPayload.swift
+++ b/Sources/APNSwift/APNSwiftPayload.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the APNSwift open source project
 //
-// Copyright (c) 2019 the APNSwift project authors
+// Copyright (c) 2019-2020 the APNSwift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,15 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-
-import NIO
-import NIOHTTP1
-import NIOHTTP2
-
-/// This is a protocol which allows developers to construct their own Notification payload
-public protocol APNSwiftNotification: Encodable {
-    var aps: APNSwiftPayload { get }
-}
 
 /// This structure provides the data structure for an APNS Payload
 public struct APNSwiftPayload: Encodable {

--- a/Sources/APNSwift/APNSwiftRequest.swift
+++ b/Sources/APNSwift/APNSwiftRequest.swift
@@ -23,15 +23,15 @@ public protocol APNSwiftNotification: Encodable {
 
 /// This structure provides the data structure for an APNS Payload
 public struct APNSwiftPayload: Encodable {
-    public let alert: APNSwiftAlert?
+    public let alert: APNSwift.APNSwiftAlert?
     public let badge: Int?
-    public let sound: APNSwiftSoundType?
+    public let sound: APNSwift.APNSwiftSoundType?
     public let contentAvailable: Int?
     public let mutableContent: Int?
     public let category: String?
     public let threadID: String?
 
-    public init(alert: APNSwiftAlert? = nil, badge: Int? = nil, sound: APNSwiftSoundType? = nil, hasContentAvailable: Bool = false, hasMutableContent: Bool = false, category: String? = nil, threadID: String? = nil) {
+    public init(alert: APNSwift.APNSwiftAlert? = nil, badge: Int? = nil, sound: APNSwift.APNSwiftSoundType? = nil, hasContentAvailable: Bool = false, hasMutableContent: Bool = false, category: String? = nil, threadID: String? = nil) {
         self.alert = alert
         self.badge = badge
         self.sound = sound
@@ -49,113 +49,5 @@ public struct APNSwiftPayload: Encodable {
         case mutableContent = "mutable-content"
         case category
         case threadID = "thread-id"
-    }
-    /// This structure provides the data structure for an APNS Alert
-    public struct APNSwiftAlert: Codable {
-        public let title: String?
-        public let subtitle: String?
-        public let body: String?
-        public let titleLocKey: String?
-        public let titleLocArgs: [String]?
-        public let actionLocKey: String?
-        public let locKey: String?
-        public let locArgs: [String]?
-        public let launchImage: String?
-
-        /**
-         This structure provides the data structure for an APNS Alert
-         - Parameter title: The title to be displayed to the user.
-         - Parameter subtitle: The subtitle to be displayed to the user.
-         - Parameter body: The body of the push notification.
-         - Parameter titleLocKey: The key to a title string in the Localizable.strings file for the current
-         localization.
-         - Parameter titleLocArgs: Variable string values to appear in place of the format specifiers in
-         title-loc-key.
-         - Parameter actionLocKey: The string is used as a key to get a localized string in the current localization
-         to use for the right button’s title instead of “View”.
-         - Parameter locKey: A key to an alert-message string in a Localizable.strings file for the current
-         localization (which is set by the user’s language preference).
-         - Parameter locArgs: Variable string values to appear in place of the format specifiers in loc-key.
-         - Parameter launchImage: The filename of an image file in the app bundle, with or without the filename
-         extension.
-
-         For more information see:
-         [Payload Key Reference](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#)
-         ### Usage Example: ###
-         ````
-         let alert = Alert(title: "Hey There", subtitle: "Subtitle", body: "Body")
-         ````
-         */
-        public init(title: String? = nil, subtitle: String? = nil, body: String? = nil,
-                    titleLocKey: String? = nil, titleLocArgs: [String]? = nil, actionLocKey: String? = nil,
-                    locKey: String? = nil, locArgs: [String]? = nil, launchImage: String? = nil) {
-            self.title = title
-            self.subtitle = subtitle
-            self.body = body
-            self.titleLocKey = titleLocKey
-            self.titleLocArgs = titleLocArgs
-            self.actionLocKey = actionLocKey
-            self.locKey = locKey
-            self.locArgs = locArgs
-            self.launchImage = launchImage
-        }
-
-        enum CodingKeys: String, CodingKey {
-            case title
-            case subtitle
-            case body
-            case titleLocKey = "title-loc-key"
-            case titleLocArgs = "title-loc-args"
-            case actionLocKey = "action-loc-key"
-            case locKey = "loc-key"
-            case locArgs = "loc-args"
-            case launchImage = "launch-image"
-        }
-    }
-    public struct APNSSoundDictionary: Encodable {
-        public let critical: Int
-        public let name: String
-        public let volume: Double
-
-        /**
-         Initialize an APNSSoundDictionary
-         - Parameter critical: The critical alert flag. Set to true to enable the critical alert.
-         - Parameter sound: The apps path to a sound file.
-         - Parameter volume: The volume for the critical alert’s sound. Set this to a value between 0.0 (silent) and 1.0 (full volume).
-
-         For more information see:
-         [Payload Key Reference](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#)
-         ### Usage Example: ###
-         ````
-         let apsSound = APNSSoundDictionary(isCritical: true, name: "cow.wav", volume: 0.8)
-         let aps = APNSwiftPayload(alert: alert, badge: 1, sound: .dictionary(apsSound))
-         ````
-         */
-        public init(isCritical: Bool, name: String, volume: Double) {
-            self.critical = isCritical ? 1 : 0
-            self.name = name
-            self.volume = volume
-        }
-    }
-    /**
-     An enum to define how to use sound.
-     - Parameter string: use this for a normal alert sound
-     - Parameter critical: use for a critical alert type
-     */
-    public enum APNSwiftSoundType: Encodable {
-        case normal(String)
-        case critical(APNSSoundDictionary)
-    }
-}
-
-extension APNSwiftPayload.APNSwiftSoundType {
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        switch self {
-        case .normal(let string):
-            try container.encode(string)
-        case .critical(let dict):
-            try container.encode(dict)
-        }
     }
 }

--- a/Sources/APNSwift/APNSwiftSound.swift
+++ b/Sources/APNSwift/APNSwiftSound.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2020 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 public struct APNSSoundDictionary: Encodable {
     public let critical: Int
     public let name: String

--- a/Sources/APNSwift/APNSwiftSound.swift
+++ b/Sources/APNSwift/APNSwiftSound.swift
@@ -1,0 +1,46 @@
+public struct APNSSoundDictionary: Encodable {
+    public let critical: Int
+    public let name: String
+    public let volume: Double
+
+    /**
+     Initialize an APNSSoundDictionary
+     - Parameter critical: The critical alert flag. Set to true to enable the critical alert.
+     - Parameter sound: The apps path to a sound file.
+     - Parameter volume: The volume for the critical alert’s sound. Set this to a value between 0.0 (silent) and 1.0 (full volume).
+
+     For more information see:
+     [Payload Key Reference](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#)
+     ### Usage Example: ###
+     ````
+     let apsSound = APNSSoundDictionary(isCritical: true, name: "cow.wav", volume: 0.8)
+     let aps = APNSwiftPayload(alert: alert, badge: 1, sound: .dictionary(apsSound))
+     ````
+     */
+    public init(isCritical: Bool, name: String, volume: Double) {
+        self.critical = isCritical ? 1 : 0
+        self.name = name
+        self.volume = volume
+    }
+}
+/**
+ An enum to define how to use sound.
+ - Parameter string: use this for a normal alert sound
+ - Parameter critical: use for a critical alert type
+ */
+public enum APNSwiftSoundType: Encodable {
+    case normal(String)
+    case critical(APNSSoundDictionary)
+}
+
+extension APNSwiftSoundType {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .normal(let string):
+            try container.encode(string)
+        case .critical(let dict):
+            try container.encode(dict)
+        }
+    }
+}

--- a/Sources/APNSwift/Deprecations.swift
+++ b/Sources/APNSwift/Deprecations.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the APNSwift open source project
+//
+// Copyright (c) 2020 the APNSwift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of APNSwift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 extension APNSwiftPayload {
     @available(*, deprecated, renamed: "APNSwiftAlert")
     public typealias APNSwiftAlert = APNSwift.APNSwiftAlert

--- a/Sources/APNSwift/Deprecations.swift
+++ b/Sources/APNSwift/Deprecations.swift
@@ -1,0 +1,10 @@
+extension APNSwiftPayload {
+    @available(*, deprecated, renamed: "APNSwiftAlert")
+    public typealias APNSwiftAlert = APNSwift.APNSwiftAlert
+
+    @available(*, deprecated, renamed: "APNSSoundDictionary")
+    public typealias APNSSoundDictionary = APNSwift.APNSSoundDictionary
+
+    @available(*, deprecated, renamed: "APNSwiftSoundType")
+    public typealias APNSwiftSoundType = APNSwift.APNSwiftSoundType
+}

--- a/Sources/APNSwiftExample/main.swift
+++ b/Sources/APNSwiftExample/main.swift
@@ -53,8 +53,8 @@ struct AcmeNotification: APNSwiftNotification {
     }
 }
 
-let alert = APNSwiftPayload.APNSwiftAlert(title: "Hey There", subtitle: "Subtitle", body: "Body")
-let apsSound = APNSwiftPayload.APNSSoundDictionary(isCritical: true, name: "cow.wav", volume: 0.8)
+let alert = APNSwiftAlert(title: "Hey There", subtitle: "Subtitle", body: "Body")
+let apsSound = APNSSoundDictionary(isCritical: true, name: "cow.wav", volume: 0.8)
 let aps = APNSwiftPayload(alert: alert, badge: 0, sound: .critical(apsSound), hasContentAvailable: true)
 let temp = try! JSONEncoder().encode(aps)
 let string = String(bytes: temp, encoding: .utf8)

--- a/Sources/APNSwiftPemExample/main.swift
+++ b/Sources/APNSwiftPemExample/main.swift
@@ -47,8 +47,8 @@ struct AcmeNotification: APNSwiftNotification {
     }
 }
 
-let alert = APNSwiftPayload.APNSwiftAlert(title: "Hey There", subtitle: "Subtitle", body: "Body")
-let apsSound = APNSwiftPayload.APNSSoundDictionary(isCritical: true, name: "cow.wav", volume: 0.8)
+let alert = APNSwiftAlert(title: "Hey There", subtitle: "Subtitle", body: "Body")
+let apsSound = APNSSoundDictionary(isCritical: true, name: "cow.wav", volume: 0.8)
 let aps = APNSwiftPayload(alert: alert, badge: 0, sound: .critical(apsSound), hasContentAvailable: true)
 let temp = try! JSONEncoder().encode(aps)
 let string = String(bytes: temp, encoding: .utf8)

--- a/Tests/APNSwiftTests/APNSwiftRequestTests.swift
+++ b/Tests/APNSwiftTests/APNSwiftRequestTests.swift
@@ -24,7 +24,7 @@ import XCTest
 final class APNSwiftRequestTests: XCTestCase {
 
     func testAlertEncoding() throws {
-        let alert = APNSwiftPayload.APNSwiftAlert(title: "title", subtitle: "subtitle", body: "body", titleLocKey: "titlelockey",
+        let alert = APNSwiftAlert(title: "title", subtitle: "subtitle", body: "body", titleLocKey: "titlelockey",
                           titleLocArgs: ["titlelocarg1"], actionLocKey: "actionkey", locKey: "lockey", locArgs: ["locarg1"], launchImage: "launchImage")
 
         let jsonData = try JSONEncoder().encode(alert)
@@ -63,7 +63,7 @@ final class APNSwiftRequestTests: XCTestCase {
     }
 
     func testMinimalAlertEncoding() throws {
-        let alert = APNSwiftPayload.APNSwiftAlert(title: "title", body: "body")
+        let alert = APNSwiftAlert(title: "title", body: "body")
 
         let jsonData = try JSONEncoder().encode(alert)
 


### PR DESCRIPTION
Avoids double namespacing of types used by `APNSwiftPayload`. Since they are already namespaced, they have been made top-level types. 

```swift
let alert = APNSwiftAlert...
let soundDictionary = APNSSoundDictionary...
let soundType = APNSwiftSoundType...
let payload = APNSwiftPayload...
```