### PR TITLE
Add Decode ability to APNSwiftPayload

### DIFF
--- a/Sources/APNSwift/APNSwiftNotification.swift
+++ b/Sources/APNSwift/APNSwiftNotification.swift
@@ -13,6 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// This is a protocol which allows developers to construct their own Notification payload
-public protocol APNSwiftNotification: Encodable {
+public protocol APNSwiftNotification: Codable {
     var aps: APNSwiftPayload { get }
 }

--- a/Sources/APNSwift/APNSwiftPayload.swift
+++ b/Sources/APNSwift/APNSwiftPayload.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// This structure provides the data structure for an APNS Payload
-public struct APNSwiftPayload: Encodable {
+public struct APNSwiftPayload: Codable {
     public let alert: APNSwift.APNSwiftAlert?
     public let badge: Int?
     public let sound: APNSwift.APNSwiftSoundType?

--- a/Sources/APNSwift/APNSwiftSound.swift
+++ b/Sources/APNSwift/APNSwiftSound.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct APNSSoundDictionary: Encodable {
+public struct APNSSoundDictionary: Codable, Equatable {
     public let critical: Int
     public let name: String
     public let volume: Double
@@ -42,7 +42,7 @@ public struct APNSSoundDictionary: Encodable {
  - Parameter string: use this for a normal alert sound
  - Parameter critical: use for a critical alert type
  */
-public enum APNSwiftSoundType: Encodable {
+public enum APNSwiftSoundType: Codable, Equatable {
     case normal(String)
     case critical(APNSSoundDictionary)
 }
@@ -57,4 +57,13 @@ extension APNSwiftSoundType {
             try container.encode(dict)
         }
     }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let critical = try? container.decode(APNSSoundDictionary.self) {
+      self = .critical(critical)
+    } else {
+      self = .normal(try container.decode(String.self))
+    }
+  }
 }

--- a/Tests/APNSwiftTests/APNSwiftRequestTests.swift
+++ b/Tests/APNSwiftTests/APNSwiftRequestTests.swift
@@ -85,6 +85,41 @@ final class APNSwiftRequestTests: XCTestCase {
         XCTAssertFalse(keys?.contains("loc-args") ?? false)
         XCTAssertFalse(keys?.contains("launch-image") ?? false)
     }
+  func testMinimalSwiftPayloadEncoding() throws {
+      let payload = APNSwiftPayload(alert: nil, sound: .normal("pong.wav"))
+
+      let jsonData = try JSONEncoder().encode(payload)
+
+      let jsonDic = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
+
+      let keys = jsonDic?.keys
+
+      XCTAssertTrue(keys?.contains("sound") ?? false)
+      XCTAssertTrue(jsonDic?["sound"] is String)
+      XCTAssertTrue(jsonDic?["sound"] as! String == "pong.wav")
+
+      XCTAssertFalse(keys?.contains("title") ?? false)
+      XCTAssertFalse(keys?.contains("body") ?? false)
+      XCTAssertFalse(keys?.contains("subtitle") ?? false)
+      XCTAssertFalse(keys?.contains("title-loc-key") ?? false)
+      XCTAssertFalse(keys?.contains("title-loc-args") ?? false)
+      XCTAssertFalse(keys?.contains("action-loc-key") ?? false)
+      XCTAssertFalse(keys?.contains("loc-key") ?? false)
+      XCTAssertFalse(keys?.contains("loc-args") ?? false)
+      XCTAssertFalse(keys?.contains("launch-image") ?? false)
+  }
+
+  func testMinimalSwiftPayloadDecoding() throws {
+      let payload = APNSwiftPayload(alert: APNSwiftAlert(title: "title", body: "body"), sound: .normal("pong.wav"))
+
+      let jsonData = try JSONEncoder().encode(payload)
+      let decodedPayload = try JSONDecoder().decode(APNSwiftPayload.self, from: jsonData)
+
+      XCTAssertEqual(payload.alert?.title, decodedPayload.alert?.title)
+      XCTAssertEqual(payload.alert?.body, decodedPayload.alert?.body)
+      XCTAssertEqual(payload.sound, decodedPayload.sound)
+  }
+
     func testResponseDecoderBasics() throws {
         let channel = EmbeddedChannel(handler: APNSwiftResponseDecoder())
 


### PR DESCRIPTION
In order to more easily make it work with [Vapor Queues](https://docs.vapor.codes/4.0/queues/) this allow me to make jobs that have Payload that are the push themselves.

As I asked [here](https://github.com/kylebrowning/APNSwift/discussions/97) I think that making them work inside jobs might be better. 