### PR TITLE
Add timeout option if connection does not receive response.

### DIFF
--- a/Sources/APNSwift/APNSwiftConfiguration.swift
+++ b/Sources/APNSwift/APNSwiftConfiguration.swift
@@ -168,6 +168,8 @@ public struct APNSwiftConfiguration {
     public var topic: String
     public var environment: Environment
     internal var logger: Logger?
+    /// Optional timeout time if the connection does not receive a response.
+    public var timeout: TimeAmount? = nil
 
     public var url: URL {
         switch environment {
@@ -197,7 +199,8 @@ public struct APNSwiftConfiguration {
         authenticationMethod: AuthenticationMethod,
         topic: String,
         environment: APNSwiftConfiguration.Environment,
-        logger: Logger? = nil
+        logger: Logger? = nil,
+        timeout: TimeAmount? = nil
     ) {
         self.topic = topic
         self.authenticationMethod = authenticationMethod
@@ -206,6 +209,7 @@ public struct APNSwiftConfiguration {
             logger[metadataKey: "origin"] = "APNSwift"
             self.logger = logger
         }
+        self.timeout = timeout
     }
 }
 

--- a/Sources/APNSwift/APNSwiftErrors.swift
+++ b/Sources/APNSwift/APNSwiftErrors.swift
@@ -18,6 +18,8 @@ import Foundation
 public struct NoResponseReceivedBeforeConnectionEnded: Error, Equatable {}
 /// An error where a request was made to Apple, but the response body buffer was nil
 public struct NoResponseBodyFromApple: Error, Equatable {}
+/// An error where no the connection received no response within the timeout period
+public struct NoResponseWithinTimeoutError: Error, Equatable {}
 
 public struct APNSwiftError: Equatable {
     public enum ResponseError: Error, Equatable {

--- a/Tests/APNSwiftTests/APNSwiftConfigurationTests.swift
+++ b/Tests/APNSwiftTests/APNSwiftConfigurationTests.swift
@@ -27,7 +27,8 @@ class APNSwiftConfigurationTests: XCTestCase {
                 teamIdentifier: "MY_TEAM_ID"
             ),
             topic: "MY_TOPIC",
-            environment: environment
+            environment: environment,
+            timeout: .seconds(5)
         )
 
         switch environment {
@@ -46,6 +47,7 @@ class APNSwiftConfigurationTests: XCTestCase {
             XCTFail("expected JWT auth method")
         }
         XCTAssertEqual(apnsConfiguration.topic, "MY_TOPIC")
+        XCTAssertEqual(apnsConfiguration.timeout, .seconds(5))
 
     }
 

--- a/Tests/APNSwiftTests/APNSwiftRequestTests.swift
+++ b/Tests/APNSwiftTests/APNSwiftRequestTests.swift
@@ -304,7 +304,6 @@ final class APNSwiftRequestTests: XCTestCase {
         // Should have changed
         XCTAssertFalse(newCachedToken == bearerToken.currentBearerToken)
         bearerToken.cancel()
-        
     }
 
     let validAuthKey = """


### PR DESCRIPTION
This PR provides a work-around for when Apple servers does not return any response, and therefore leaves the connection occupied and blocked. This means in production environments, with 2 connections you are forced to restart the server, if two attempts to send a push notifications hangs because of Apple. This actually happens pretty frequently.

The timeout is disabled by default and can be enabled by setting the `timeout` property of `APNSwiftConfiguration`.

I've tested this in our production environment, and fixes the issues we were having with the connections blocking.