### PR TITLE
Update APS Payload Keys for iOS 13

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,14 +9,19 @@ needs to be listed here.
 
 ### Contributors
 
+- Craig Newell <craign@ieee.org>
 - Eduardo Perez <sabeatra@gmail.com>
 - Florian Reinhart <florian.reinhart@gmail.com>
+- Jeffrey Macko <mackoj@users.noreply.github.com>
 - Kyle Browning <kylebrowning@me.com>
 - Laurent Gaches <laurent@binimo.com>
+- Mads Odgaard <mads@madsodgaard.com>
+- Roderic Campbell <roderic@gmail.com>
 - Tanner <me@tanner.xyz>
 - Tanner Nelson <me@tanner.xyz>
 - grosch <scott.grosch@icloud.com>
 - itcohorts <ben@itcohorts.com>
+- tanner0101 <me@tanner.xyz>
 
 **Updating this list**
 

--- a/Sources/APNSwift/APNSwiftPayload.swift
+++ b/Sources/APNSwift/APNSwiftPayload.swift
@@ -21,8 +21,11 @@ public struct APNSwiftPayload: Codable {
     public let mutableContent: Int?
     public let category: String?
     public let threadID: String?
+    public let targetContentId: String?
+    public let interruptionLevel: String?
+    public let relevanceScore: Float?
 
-    public init(alert: APNSwift.APNSwiftAlert? = nil, badge: Int? = nil, sound: APNSwift.APNSwiftSoundType? = nil, hasContentAvailable: Bool = false, hasMutableContent: Bool = false, category: String? = nil, threadID: String? = nil) {
+    public init(alert: APNSwift.APNSwiftAlert? = nil, badge: Int? = nil, sound: APNSwift.APNSwiftSoundType? = nil, hasContentAvailable: Bool = false, hasMutableContent: Bool = false, category: String? = nil, threadID: String? = nil, targetContentId: String? = nil, interruptionLevel: String? = nil, relevanceScore: Float? = nil) {
         self.alert = alert
         self.badge = badge
         self.sound = sound
@@ -30,6 +33,9 @@ public struct APNSwiftPayload: Codable {
         self.mutableContent = hasMutableContent ? 1 : 0
         self.category = category
         self.threadID = threadID
+        self.targetContentId = targetContentId
+        self.interruptionLevel = interruptionLevel
+        self.relevanceScore = relevanceScore
     }
 
     enum CodingKeys: String, CodingKey {
@@ -40,5 +46,8 @@ public struct APNSwiftPayload: Codable {
         case mutableContent = "mutable-content"
         case category
         case threadID = "thread-id"
+        case targetContentId = "target-content-id"
+        case interruptionLevel = "interruption-level"
+        case relevanceScore = "relevance-score"
     }
 }


### PR DESCRIPTION
Apple has added some extra keys since iOS 13 so update the list of known payload dictionary keys.