### PR TITLE
Fix dependency issue with swift-nio-ssl

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.10.1"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.13.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0"),


### PR DESCRIPTION
Hi,

This is a small PR to fix something that prevent our backend to compile.

Since you are using `TLSConfiguration.makeClientConfiguration()` and it has been introduce in this PR(https://github.com/apple/swift-nio-ssl/pull/299). Please update your base requirement of `swift-nio-ssl` to when it has been introduced.

https://github.com/kylebrowning/APNSwift/blob/e7645362c051fb12c28ed290c6e7f6918596d25b/Sources/APNSwift/APNSwiftConnection.swift#L90

Please consider release a point update.

Thanks