### PR TITLE
iOS Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ let package = Package(
     name: "apnswift",
     platforms: [
         .macOS(.v10_15),
+        .iOS(.v13),
     ],
     products: [
         .executable(name: "APNSwiftExample", targets: ["APNSwiftExample"]),


### PR DESCRIPTION
Add iOS 13+ to supported platforms so APNSwift can be compiled with iOS targets.
During development, I found it useful to run the push server on my iPhone.