### PR TITLE
[feat] Mark content boolean properties in init as optional

### DIFF
--- a/Sources/APNSwift/APNSwiftPayload.swift
+++ b/Sources/APNSwift/APNSwiftPayload.swift
@@ -25,12 +25,22 @@ public struct APNSwiftPayload: Codable {
     public let interruptionLevel: String?
     public let relevanceScore: Float?
 
-    public init(alert: APNSwift.APNSwiftAlert? = nil, badge: Int? = nil, sound: APNSwift.APNSwiftSoundType? = nil, hasContentAvailable: Bool = false, hasMutableContent: Bool = false, category: String? = nil, threadID: String? = nil, targetContentId: String? = nil, interruptionLevel: String? = nil, relevanceScore: Float? = nil) {
+    public init(alert: APNSwift.APNSwiftAlert? = nil, badge: Int? = nil, sound: APNSwift.APNSwiftSoundType? = nil, hasContentAvailable: Bool? = false, hasMutableContent: Bool? = false, category: String? = nil, threadID: String? = nil, targetContentId: String? = nil, interruptionLevel: String? = nil, relevanceScore: Float? = nil) {
         self.alert = alert
         self.badge = badge
         self.sound = sound
-        self.contentAvailable = hasContentAvailable ? 1 : 0
-        self.mutableContent = hasMutableContent ? 1 : 0
+        if let hasContentAvailable = hasContentAvailable {
+            self.contentAvailable = hasContentAvailable ? 1 : 0
+        }
+        else {
+            self.contentAvailable = nil
+        }
+        if let hasMutableContent = hasMutableContent {
+            self.mutableContent = hasMutableContent ? 1 : 0
+        }
+        else {
+            self.mutableContent = nil
+        }
         self.category = category
         self.threadID = threadID
         self.targetContentId = targetContentId


### PR DESCRIPTION
Recently I discovered that my background notifications were not being delivered to my application anymore. Upon inspecting the `aps` part of the payload being sent, it would set `"content-available"` and `"mutable-content"` properties. The presence of `"mutable-content"` would cause the payload to not be delivered at all (in my app testing at least).

I have left the initialisers in their original state (of `false` rather than `nil`) in order to not introduce any breaking changes